### PR TITLE
Handle custom iOS AppDelegate

### DIFF
--- a/SingularSDK/Editor/SingularEditorParams.cs
+++ b/SingularSDK/Editor/SingularEditorParams.cs
@@ -1,0 +1,36 @@
+using UnityEditor;
+
+namespace Singular.Editor
+{
+    public static class SingularEditorParams
+    {
+        private const string IOS_USE_CUSTOM_APP_DELEGATE_EDITOR_KEY = "SingularIsIOSUseCustomAppDelegate";
+        internal static bool IsIOSUseCustomAppDelegate => EditorPrefs.GetInt( IOS_USE_CUSTOM_APP_DELEGATE_EDITOR_KEY, 0 ) == 1;
+
+        // IOS APP USES CUSTOM APP DELEGATE
+
+        [MenuItem( "Window/Singular/My iOS App use a custom AppDelegate", true )]
+        private static bool _MenuItem_iOSUseCustomAppDelegate()
+        {
+            return !IsIOSUseCustomAppDelegate;
+        }
+        [MenuItem( "Window/Singular/My iOS App use a custom AppDelegate" )]
+        private static void MenuItem_iOSUseCustomAppDelegate()
+        {
+            EditorPrefs.SetInt( IOS_USE_CUSTOM_APP_DELEGATE_EDITOR_KEY, 1 );
+        }
+
+        // IOS APP DON'T USES CUSTOM APP DELEGATE
+
+        [MenuItem( "Window/Singular/My iOS App don't use a custom AppDelegate", true )]
+        private static bool _MenuItem_iOSDontUseCustomAppDelegate()
+        {
+            return IsIOSUseCustomAppDelegate;
+        }
+        [MenuItem( "Window/Singular/My iOS App don't use a custom AppDelegate" )]
+        private static void MenuItem_iOSDontUseCustomAppDelegate()
+        {
+            EditorPrefs.SetInt( IOS_USE_CUSTOM_APP_DELEGATE_EDITOR_KEY, 0 );
+        }
+    }
+}

--- a/SingularSDK/Editor/SingularEditorParams.cs.meta
+++ b/SingularSDK/Editor/SingularEditorParams.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 58e0c8cb5925438790ea3a52154a5c20
+timeCreated: 1720604858

--- a/SingularSDK/Editor/SingularPostBuild.cs
+++ b/SingularSDK/Editor/SingularPostBuild.cs
@@ -1,5 +1,4 @@
-﻿//#define UNITY_IOS
-using System;
+﻿using System;
 using System.Xml;
 using UnityEngine;
 using UnityEditor;

--- a/SingularSDK/Editor/SingularPostBuild.cs
+++ b/SingularSDK/Editor/SingularPostBuild.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿//#define UNITY_IOS
+using System;
 using System.Xml;
 using UnityEngine;
 using UnityEditor;
@@ -13,36 +14,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 
 namespace Singular.Editor {
-
-    private const string IOS_USE_CUSTOM_APP_DELEGATE_EDITOR_KEY = "SingularIsIOSUseCustomAppDelegate";
-    private static bool IsIOSUseCustomAppDelegate => EditorPrefs.GetInt( IOS_USE_CUSTOM_APP_DELEGATE_EDITOR_KEY, 0 ) == 1;
-
-    // IOS APP USES CUSTOM APP DELEGATE
-
-    [MenuItem( "Window/Singular/My iOS App use a custom AppDelegate", true )]
-    private static bool _MenuItem_iOSUseCustomAppDelegate()
-    {
-        return !IsIOSUseCustomAppDelegate;
-    }
-    [MenuItem( "Window/Singular/My iOS App use a custom AppDelegate" )]
-    private static void MenuItem_iOSUseCustomAppDelegate()
-    {
-        EditorPrefs.SetInt( IOS_USE_CUSTOM_APP_DELEGATE_EDITOR_KEY, 1 )
-    }
-
-    // IOS APP DON'T USES CUSTOM APP DELEGATE
-
-    [MenuItem( "Window/Singular/My iOS App don't use a custom AppDelegate", true )]
-    private static bool _MenuItem_iOSDontUseCustomAppDelegate()
-    {
-        return IsIOSUseCustomAppDelegate;
-    }
-    [MenuItem( "Window/Singular/My iOS App don't use a custom AppDelegate" )]
-    private static void MenuItem_iOSDontUseCustomAppDelegate()
-    {
-        EditorPrefs.SetInt( IOS_USE_CUSTOM_APP_DELEGATE_EDITOR_KEY, 0 )
-    }
-
+    
 #if UNITY_IOS
 
 public class SingularPostBuild
@@ -89,7 +61,7 @@ public class SingularPostBuild
 
     static void HandleCustomAppDelegate(string pathToBuiltProject)
     {
-        if( !IsIOSUseCustomAppDelegate )
+        if( !SingularEditorParams.IsIOSUseCustomAppDelegate )
             return;
 
         // get the path to SingularAppDelegate.m in built project


### PR DESCRIPTION
Handle projects with custom iOS app delegate, by commenting the App Delegate directive in the SingularAppDelegate.m file

 - Added a menu inside Window/Singular to set if iOS app uses a custom AppDelegate or not and saves the value in an EditorPref variable.
 - If iOS app uses a custom AppDelegate, comment out the IMPL_APP_CONTROLLER_SUBCLASS directive in SingularAppDelegate.m file after the build.