### PR TITLE
Rc/5.2.1

### DIFF
--- a/SingularSDK/Editor/Dependencies.xml
+++ b/SingularSDK/Editor/Dependencies.xml
@@ -10,7 +10,7 @@
     <androidPackage spec="com.google.android.gms:play-services-ads-identifier:18.0.1"> </androidPackage>
   </androidPackages>
   <iosPods>
-    <iosPod name="Singular-SDK" version="12.4.4" minTargetSdk="12.0" bitcodeEnabled="false" addToAllTargets="false">
+    <iosPod name="Singular-SDK" version="12.5.0" minTargetSdk="12.0" bitcodeEnabled="false" addToAllTargets="false">
     </iosPod>
   </iosPods>
 </dependencies>

--- a/SingularSDK/Runtime/SingularSDK.cs
+++ b/SingularSDK/Runtime/SingularSDK.cs
@@ -28,7 +28,7 @@ namespace Singular
         public static bool Initialized { get; private set; } = false;
         
         private const string UNITY_WRAPPER_NAME = "Unity";
-        private const string UNITY_VERSION      = "5.2.0";
+        private const string UNITY_VERSION      = "5.2.1";
         
         // ios-only:
         [Obsolete]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "singular-unity-package",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "displayName": "Singular",
   "description": "Singular Unity Package",
   "type": "library",


### PR DESCRIPTION
RC 5.2.1:
switched to native iOS static framework version 12.5.0 from pods using EDM4U, and integrates the generous PR contribution from https://github.com/singular-labs/Singular-Unity-SDK/pull/7 