### PR TITLE
Change package name to match naming standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "singular-unity-package",
+  "name": "com.singular.unitysdk",
   "version": "5.2.1",
   "displayName": "Singular",
   "description": "Singular Unity Package",


### PR DESCRIPTION
package name should conform to reverse domain name notation with at least 3 components (tld.org-name.pkg-name)

This is a standard used in all unity packages and expected by package managers.
Without the notation tools like OpenUPM or org internal package managers have problems using this package.