### PR TITLE
Change `Application.isEditor` check order in `InitializeSingularSDK` in editor

### DIFF
--- a/SingularSDK/Runtime/SingularSDK.cs
+++ b/SingularSDK/Runtime/SingularSDK.cs
@@ -131,6 +131,9 @@ namespace Singular
             if (Initialized)
                 return;
 
+            if (Application.isEditor)
+                return;
+            
             if (!instance)
             {
                 SingularUnityLogger.LogError("SingularSDK InitializeSingularSDK, no instance available - cannot initialize");
@@ -138,11 +141,6 @@ namespace Singular
             }
 
             SingularUnityLogger.LogDebug(string.Format("SingularSDK InitializeSingularSDK, APIKey={0}", instance.SingularAPIKey));
-
-            if (Application.isEditor)
-            {
-                return;
-            }
 
             SingularConfig config = BuildSingularConfig();
 

--- a/SingularSDK/Runtime/SingularSDK.cs
+++ b/SingularSDK/Runtime/SingularSDK.cs
@@ -96,7 +96,7 @@ namespace Singular
         #endregion
         
         // The Singular SDK is initialized here
-        void Awake()
+        private void Awake()
         {
             // init logger - matches native layer logging levels
             SingularUnityLogger.EnableLogging(enableLogging);
@@ -833,7 +833,7 @@ namespace Singular
 #endif
         }
 
-        void OnApplicationPause(bool paused)
+        private void OnApplicationPause(bool paused)
         {
             if (!Initialized || !instance)
                 return;
@@ -855,7 +855,7 @@ namespace Singular
 #endif
         }
 
-        void OnApplicationQuit()
+        private void OnApplicationQuit()
         {
             if (Application.isEditor)
             {

--- a/SingularSDK/Runtime/SingularSDK.cs
+++ b/SingularSDK/Runtime/SingularSDK.cs
@@ -204,10 +204,6 @@ namespace Singular
             return config;
         }
 
-        public void Update()
-        {
-        }
-
 #if UNITY_ANDROID
     private static void initSDK(SingularConfig config) {
         SingularUnityLogger.LogDebug("UNITY_ANDROID - init Is called");


### PR DESCRIPTION
# Description
## 1. `Awake` and `InitializeSingularSDK` initialization flow order in editor

While initializing SingularSDK via `InitializeSingularSDK` in the Unity Editor I've encountered error `SingularSDK InitializeSingularSDK, no instance available - cannot initialize`.

It seems like strange behavior to Me because this error occurs when there's no `SingularSDK` instance, however, it's impossible for the instance to exist because there's a check in `Awake` before its creation to ensure, if We are in the editor, then `return`.

So in My PR I've changed `Awake` to be more like `InitializeSingularSDK`: firstly check if We're in the editor and then - if We have an instance of `SingularSDK`

Before fix:
- Awake - `if(Application.isEditor)` -> `if(instance)`
- InitializeSingularSDK - `if(!instance)` -> `if(Application.isEditor)`

After fix:
- Awake - `if(Application.isEditor)` -> `if(instance)`
- InitializeSingularSDK - `if(Application.isEditor)` -> `if(!instance)`

[Commit](https://github.com/singular-labs/Singular-Unity-SDK/commit/fad842b4ae6278bbc65a41bd8ce70d55cc9442df#diff-1814d8d35ecc9ea69078516c65b300f2572873230f4a0140cc2833d8c04b1f9aL131-R147)

## 2. `Private` keywords, whitespaces and unused methods
Also I've added `private` keywords to Unity methods and deleted some whitespaces + unused `Update` method

[Commit 'whitespaces and unused methods'](https://github.com/singular-labs/Singular-Unity-SDK/commit/0918f623536f30ef53ea58a9627360adf9834b58#diff-1814d8d35ecc9ea69078516c65b300f2572873230f4a0140cc2833d8c04b1f9aR204)

[Commit 'access keywords'](https://github.com/singular-labs/Singular-Unity-SDK/commit/9cbb7a31e4d3b86eb5b06cc1779e30b01bfa224f#diff-1814d8d35ecc9ea69078516c65b300f2572873230f4a0140cc2833d8c04b1f9aL96-R861)