### PR TITLE
Automatically define `SINGULAR_SDK_IAP_ENABLED` when Unity IAP package is installed

### DIFF
--- a/SingularSDK/Runtime/SingularSDK.asmdef
+++ b/SingularSDK/Runtime/SingularSDK.asmdef
@@ -11,6 +11,12 @@
     "precompiledReferences": [],
     "autoReferenced": true,
     "defineConstraints": [],
-    "versionDefines": [],
+    "versionDefines": [
+        {
+            "name": "com.unity.purchasing",
+            "expression": "",
+            "define": "SINGULAR_SDK_IAP_ENABLED"
+        }
+    ],
     "noEngineReferences": false
 }


### PR DESCRIPTION
This PR adds a [Version Define](https://docs.unity3d.com/Manual/class-AssemblyDefinitionImporter.html#version-defines) to the SingularSDK asmdef, so that the scripting symbol `SINGULAR_SDK_IAP_ENABLED` is defined automatically if the Unity IAP package is installed in the Unity project. This way we don't need to manually add this scripting symbol to each platform to be able to call `SingularSDK.InAppPurchase`.