### PR TITLE
Add a link.xml for the runtime sdk to make sure no classes are stripped

### DIFF
--- a/SingularSDK/Runtime/link.xml
+++ b/SingularSDK/Runtime/link.xml
@@ -1,0 +1,3 @@
+<linker>
+	<assembly fullname="SingularSDK" preserve="all"/>
+</linker>


### PR DESCRIPTION
With Managed Stripping set to Low Deep links didn't work anymore, this makes sure that the functionality is preserved, see also https://support.singular.net/hc/en-us/requests/147468

This PR does not require to add the setting to the main link.xml in the project anymore (since that can easily be overseen and it was hard to actually find the problem, which you can also see in the support ticket). Hopefully this change will save others some time :)