### PR TITLE
v5.5.1-KIDS

### DIFF
--- a/SingularSDK/Runtime/SingularSDK.cs
+++ b/SingularSDK/Runtime/SingularSDK.cs
@@ -30,7 +30,7 @@ namespace Singular
         public static bool Initialized { get; private set; } = false;
         
         private const string UNITY_WRAPPER_NAME = "Unity";
-        private const string UNITY_VERSION      = "5.4.1-KIDS";
+        private const string UNITY_VERSION      = "5.5.1-KIDS";
         
         // ios-only:
         [Obsolete]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "singular-unity-kids-package",
-    "version": "5.5.0",
+    "version": "5.5.1",
     "displayName": "Singular Kids",
     "description": "Singular Unity Kids Package",
     "type": "library",


### PR DESCRIPTION
bumps and correctly aligns version name for the Singular Unity KIDS SDK