### PR TITLE
Fix SingularGlobalProperty silently failing serialization depending o…

### DIFF
--- a/SingularSDK/Runtime/SingularSDK.cs
+++ b/SingularSDK/Runtime/SingularSDK.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using UnityEngine;
+using UnityEngine.Scripting;
 #if SINGULAR_SDK_IAP_ENABLED__IAP_4 || SINGULAR_SDK_IAP_ENABLED__IAP_5
 using UnityEngine.Purchasing;
 #endif // SINGULAR_SDK_IAP_ENABLED__IAP_4 || SINGULAR_SDK_IAP_ENABLED__IAP_5
@@ -2040,6 +2041,7 @@ namespace Singular
             }
         }
 
+        [Preserve]
         private class SingularGlobalProperty
         {
             public string Key { get; set; }


### PR DESCRIPTION
**Summary**

Added _[Preserve]_ attribute to SingularGlobalProperty class to prevent Unity's managed code stripping from removing it during build optimization.

**Problem**
Unity's static code analysis doesn't detect that **SingularGlobalProperty** fields are used in JSON serialization via reflection. As a result, Unity's code stripping removes these fields during the build process, causing global properties to serialize as empty objects in the SDK when they're set **before** lib initialization (and serialized along **SingularConfig** via `ToJsonString`).

This issue has affected production releases, where games using the Singular Unity SDK didn't report global properties. We have worked around this by preserving the entire assembly.

`<assembly fullname="Singular" preserve="all"/>`

**Solution**

Added the [Preserve] attribute to the SingularGlobalProperty class, which explicitly tells Unity's code stripper to preserve this class and its members during optimization. This is the recommended upstream fix that prevents the issue at the SDK level rather than requiring downstream workarounds.
