### PR TITLE
fix: correct WebKit.framework capitalization in iOS post-build

### DIFF
--- a/SingularSDK/Editor/SingularPostBuild.cs
+++ b/SingularSDK/Editor/SingularPostBuild.cs
@@ -44,7 +44,7 @@ public class SingularPostBuild
         pbxProject.AddFrameworkToProject(targetGuid, "Security.framework", false);
         pbxProject.AddFrameworkToProject(targetGuid, "SystemConfiguration.framework", false);
         pbxProject.AddFrameworkToProject(targetGuid, "AdSupport.framework", false);
-        pbxProject.AddFrameworkToProject(targetGuid, "Webkit.framework", false);
+        pbxProject.AddFrameworkToProject(targetGuid, "WebKit.framework", false);
         pbxProject.AddFrameworkToProject(targetGuid, "StoreKit.framework", false);
         pbxProject.AddFrameworkToProject(targetGuid, "AdServices.framework", true); // optional=true
         


### PR DESCRIPTION
Fixes #42.

`SingularPostBuild.cs` added the iOS framework as `"Webkit.framework"`, but Apple's framework is **`WebKit.framework`** (capital `K`). Framework names are case-sensitive, so the incorrect casing can lead to linker/build problems on case-sensitive setups.

Single-character change on the `AddFrameworkToProject` line; the surrounding frameworks (`AdSupport.framework`, `StoreKit.framework`, etc.) are already correctly cased.